### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -1,5 +1,18 @@
 (function(){
   var host = document.currentScript.getAttribute('data-host') || window.location.origin;
+  try {
+    // Allow only http(s) protocol, and optionally enforce same origin
+    if (host !== window.location.origin) {
+      var hostUrl = new URL(host, window.location.origin);
+      if (hostUrl.protocol !== "https:" && hostUrl.protocol !== "http:") {
+        console.warn('nightclub widget: Invalid data-host protocol. Falling back to window.location.origin');
+        host = window.location.origin;
+      }
+    }
+  } catch (e) {
+    console.warn('nightclub widget: Invalid data-host. Falling back to window.location.origin');
+    host = window.location.origin;
+  }
   var eventId = document.currentScript.getAttribute('data-event-id');
   var ref = document.currentScript.getAttribute('data-ref') || '';
   if(!eventId){ console.error('nightclub widget: missing data-event-id'); return; }


### PR DESCRIPTION
Potential fix for [https://github.com/bandandolando-hue/nightclub-blackkey-stack/security/code-scanning/1](https://github.com/bandandolando-hue/nightclub-blackkey-stack/security/code-scanning/1)

To fix this vulnerability, we need to ensure that values from `data-host` are safe before assigning them to be used as the iframe's source. The best solution is to strictly validate `host` as a URL, only permitting values with trusted protocols (ideally, restricting to `http://` and `https://`), and preferably ensuring that the origin matches an allowed set (for example, the same origin as the current script or a whitelist). If no validation is possible, it's safest to simply always use a fixed, trusted host (the default, `window.location.origin`).  
In this scenario, we can implement a check:  
- If `data-host` is present, check that it starts with `https://` or (optionally) `http://` and is a valid URL, and optionally that it matches the current origin (if required).
- If not valid, revert to `window.location.origin` and perhaps log an error.

This should be implemented right after reading the attribute, before its use in constructing the iframe's `src`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
